### PR TITLE
Extract support card type

### DIFF
--- a/cmd/supportcard.js
+++ b/cmd/supportcard.js
@@ -50,7 +50,7 @@ const updateParameters = (data, originalParams) => {
   params.title                = noop(params.title);
   params.title_jp             = fetchTextData(76).replace("[","").replace("]","");
   params.rarity               = ["", "R", "SR", "SSR"][data.rarity] || params.rarity || "";
-  params.type                 = noop(params.type);
+  params.type                 = data.command_id;
   params.series               = noop(params.series);
   params.obtain               = noop(params.obtain);
   params.release_date         = noop(params.release_date);


### PR DESCRIPTION
Found out how to extract this. Current plan is to extract based on ID, and then handle mapping ID to string via wiki template.